### PR TITLE
Handle new ack behavior in 0.8 correctly

### DIFF
--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -42,7 +42,11 @@ module Poseidon
                                 timeout,
                                 messages_for_topics) 
       send_request(req)
-      read_response(ProduceResponse)
+      if required_acks != 0
+        read_response(ProduceResponse)
+      else
+        true
+      end
     end
 
     # Execute a fetch call


### PR DESCRIPTION
Don't try to read a response from the server when :required_acks is 0.
