### PR TITLE
Rake simple integration test was failing with: 'run_command': sh: -c: li...

### DIFF
--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -73,7 +73,7 @@ class JavaRunner
   def daemon_controller
     @dc ||= DaemonController.new(
       :identifier => @id,
-      :start_command => "#{@start_cmd} #{config_path} &>> #{log_path} & echo $! > #{pid_path}",
+      :start_command => "#{@start_cmd} #{config_path} >>#{log_path} 2>&1 & echo $! > #{pid_path}",
       :ping_command => [:tcp, '127.0.0.1', @port],
       :pid_file => pid_path,
       :log_file => log_path,


### PR DESCRIPTION
...ne 0: syntax error near unexpected token '>' (DaemonController::StartError)
