### PR TITLE
Consumer fail with a checksum error 

### DIFF
--- a/lib/poseidon/message.rb
+++ b/lib/poseidon/message.rb
@@ -34,6 +34,12 @@ module Poseidon
     def self.read(buffer)
       m = Message.new
       m.struct = Protocol::MessageWithOffsetStruct.read(buffer)
+
+      # Return nil if the message is truncated.
+      if m.struct.message.truncated?
+        return nil
+      end
+
       if m.struct.message.checksum_failed?
         raise Errors::ChecksumError
       end

--- a/lib/poseidon/protocol.rb
+++ b/lib/poseidon/protocol.rb
@@ -23,7 +23,7 @@ module Poseidon
     MessageStruct = ProtocolStruct.new(:magic_type => :int8,
                                        :attributes => :int8,
                                        :key => :bytes,
-                                       :value => :bytes).prepend_size.prepend_crc32
+                                       :value => :bytes).prepend_size.prepend_crc32.truncatable
     MessageWithOffsetStruct = ProtocolStruct.new(:offset => :int64,
                                                  :message => MessageStruct)
      

--- a/lib/poseidon/protocol/response_buffer.rb
+++ b/lib/poseidon/protocol/response_buffer.rb
@@ -56,6 +56,10 @@ module Poseidon
         end
       end
 
+      def bytes_remaining
+        @s.size - @pos
+      end
+
       def eof?
         @pos == @s.size
       end

--- a/spec/integration/simple/simple_producer_and_consumer_spec.rb
+++ b/spec/integration/simple/simple_producer_and_consumer_spec.rb
@@ -26,11 +26,16 @@ describe "simple producer and consumer" do
                                :type => :sync,
                                :required_acks => 1)
 
+      @consumer = PartitionConsumer.new("test_consumer", "localhost", 9092,
+                                        "topic_simple_producer_and_consumer", 0, -1)
+
+      # Read up to the end of the current messages
+      @consumer.fetch
+
+      # First Batch
       messages = [MessageToSend.new("topic_simple_producer_and_consumer", "Hello World")]
       expect(@producer.send_messages(messages)).to eq(true)
 
-      @consumer = PartitionConsumer.new("test_consumer", "localhost", 9092,
-                                        "topic_simple_producer_and_consumer", 0, -2)
       messages = @consumer.fetch
       expect(messages.last.value).to eq("Hello World")
 
@@ -46,7 +51,7 @@ describe "simple producer and consumer" do
       expect(messages.empty?).to eq(true)
     end
 
-    it "fetches messages from the earliest offset" do
+    it "fetches larger messages with a larger max bytes size" do
       @producer = Producer.new(["localhost:9092"],
                                 "test_client",
                                 :type => :sync,

--- a/spec/unit/message_spec.rb
+++ b/spec/unit/message_spec.rb
@@ -56,6 +56,23 @@ describe Message do
     end
   end
 
+  describe "truncated message" do
+    before(:each) do
+      m = Message.new(:value => "value",
+                      :key => "key",
+                      :topic => "topic")
+
+      req_buf = Protocol::RequestBuffer.new
+      m.write(req_buf)
+
+      @s = req_buf.to_s
+    end
+
+    it "reading returns nil" do
+      expect(Message.read(Protocol::ResponseBuffer.new(@s[0..-4]))).to eq(nil)
+    end
+  end
+
   context "invalid utf8 string for value" do
     it "builds the payload without error" do
       s = "asdf\xffasdf"


### PR DESCRIPTION
When fetching a topic with earlier_offset that has an amount of messages major than max_bytes it fail with a checksum error.

there's a modified integration test on my project fork (https://github.com/v-a/poseidon branch "fetch_fail_int_test")  that shows the issue
