### PR TITLE
Add a `second_latest_offset` magic offset symbol to fetch all new events plus the one event which occurred most recently.

### DIFF
--- a/spec/unit/partition_consumer_spec.rb
+++ b/spec/unit/partition_consumer_spec.rb
@@ -69,6 +69,14 @@ describe PartitionConsumer do
         expect(pc.next_offset).to eq(0)
       end
     end
+
+    context "when offset is :second_last_offset" do
+      it "resolves offset to one less than the server offset" do
+        pc = PartitionConsumer.new("test_client", "localhost", 9092, "test_topic",
+                                   0, :second_latest_offset)
+        expect(pc.next_offset).to eq(99)
+      end
+    end
   end
 
   describe "fetching messages" do


### PR DESCRIPTION
For anyone listening to a stream of aggregates or something like this it is useful to know what the most recent aggregate was immediately instead of having to wait for the next one to get produced. I added another magic symbol to ask the `PartitionConsumer` to start consuming from the latest offset minus one in order to get that most recent event.

I hope this is ok, one could make the argument that this starts a slipery slope of asking for `third_latest_offset` or whatever but I think this is reasonable enough. The other option would be to make `offset` an `attr_accessible` on the  `PartitionConsumer` so that client code that knows what it is doing can resolve the latest offset and then subtract one from the internal state of the consumer.

Thanks for making an awesome gem @bpot, this was super easy!
