### PR TITLE
Negative offsets

### DIFF
--- a/spec/unit/partition_consumer_spec.rb
+++ b/spec/unit/partition_consumer_spec.rb
@@ -110,6 +110,16 @@ describe PartitionConsumer do
       end
     end
 
+    context "when negative offset beyond beginning of partition is passed" do
+      it "starts from the earliest offset" do
+        @pc = PartitionConsumer.new("test_client", "localhost", 9092, "test_topic", 0, -10000)
+        pfr = @response.topic_fetch_responses.first.partition_fetch_responses.first
+        pfr.stub!(:error).and_return(1, 1, 0)
+
+        @pc.fetch
+      end
+    end
+
     context "when call returns an error" do
       it "is raised" do
         pfr = @response.topic_fetch_responses.first.partition_fetch_responses.first


### PR DESCRIPTION
I modified the `second_latest_offset` branch to take a more general negative offset instead. This introduces an API change, because you can no longer pass `-1` or `-2` yourself to get latest or earliest offset respectively as specified in the Kafka protocol. I believe this is a reasonable change where the users of Poseidon should not have to care this deeply of the protocol underneath—that's Poseidon's job. Instead, we use negative numbers to specify a negative offset. This is done by getting the latest event's offset and then setting the offset to that minus `@offset`.

Please review:
@bpot @fw42 @hornairs 
