### PR TITLE
Add Poseidon::Consumer

### DIFF
--- a/lib/poseidon.rb
+++ b/lib/poseidon.rb
@@ -96,6 +96,7 @@ module Poseidon
 end
 
 # Public API
+require "poseidon/consumer"
 require "poseidon/message_to_send"
 require "poseidon/producer"
 require "poseidon/fetched_message"

--- a/lib/poseidon/consumer.rb
+++ b/lib/poseidon/consumer.rb
@@ -1,0 +1,109 @@
+require 'thread'
+
+module Poseidon
+  # A Kafka Consumer that is as easy to use as possible.
+  # Automatically connects to all the partitions of a topic,
+  # and implements Enumerable for easy consuming.
+  #
+  # ## Example
+  #
+  # consumer = Poseidon::Consumer.new("test_client", %w(localhost:9092), "test_topic", :earliest_offset)
+  # first_five = consumer.take(5)
+  # # Consume indefinitely
+  # consumer.each { |message| puts message.value }
+  #
+  # @api public
+  class Consumer
+    include Enumerable
+
+    attr_reader :client_id, :seed_brokers, :topic, :offset, :options
+
+    # Create a Consumer that reads from all the partitions of a topic at once
+    #
+    # @param [String] client_id
+    #   Used to identify this client. Should be unique.
+    #
+    # @param [Enumerable<String>] seed_brokers
+    #   The initial brokers that are used for fetching the metadata.
+    #
+    # @param [Integer,Symbol] offset
+    #   Offset to start reading from.
+    #   There are a couple special offsets which can be passed as symbols:
+    #     :earliest_offset Start reading from the first offset the server has.
+    #     :latest_offset   Start reading from the latest offset the server has.
+    #
+    # @param [Hash] options
+    #   Theses options are passed to the individual PartitionConsumers
+    #
+    # @option options [:max_bytes] Maximum number of bytes to fetch
+    #   Default: 1048576 (1MB)
+    # @option options [:max_wait_ms]
+    #   How long to block until the server sends us data.
+    #   Default: 100 (100ms)
+    # @option options [:min_bytes] Smallest amount of data the server should send us.
+    #   Default: 0 (Send us data as soon as it is ready)
+    #
+    def initialize(client_id, seed_brokers, topic, offset, options = {})
+      @client_id = client_id
+      @seed_brokers = seed_brokers
+      @topic = topic
+      @offset = offset
+      @options = options
+
+      @queue = Queue.new
+    end
+
+    # Start fetching messages from all partitions at once. Expects a block
+    #
+    # You can restart consuming after stopping it before (by breaking inside
+    # the block for example) and the consumer will resume where it left off.
+    #
+    # @api public
+    def each
+      @partition_consumers ||= create_partition_consumers
+
+      begin
+        threads = @partition_consumers.map do |partition_consumer|
+          Thread.new do
+            loop do
+              fetched_messages = partition_consumer.fetch
+
+              fetched_messages.each do |fetched_message|
+                @queue << fetched_message
+              end
+            end
+          end
+        end
+
+        loop do
+          yield @queue.pop
+        end
+      ensure
+        threads.each(&:kill)
+        threads.each(&:join)
+      end
+    end
+
+    alias_method :consume, :each
+
+    private
+    def create_partition_consumers
+      cluster_metadata = fetch_cluster_metadata
+
+      topic_metadata = cluster_metadata.topic_metadata[topic]
+      (0...topic_metadata.partition_count).map do |partition|
+        lead_broker = cluster_metadata.lead_broker_for_partition(topic, partition)
+
+        PartitionConsumer.new(client_id, lead_broker.host, lead_broker.port, topic, partition, offset, options)
+      end
+    end
+
+    def fetch_cluster_metadata
+      broker_pool = BrokerPool.new(client_id, seed_brokers)
+
+      cluster_metadata = ClusterMetadata.new
+      cluster_metadata.update(broker_pool.fetch_metadata([topic]))
+      cluster_metadata
+    end
+  end
+end

--- a/lib/poseidon/consumer.rb
+++ b/lib/poseidon/consumer.rb
@@ -64,13 +64,17 @@ module Poseidon
 
       begin
         threads = @partition_consumers.map do |partition_consumer|
-          Thread.new do
-            loop do
-              fetched_messages = partition_consumer.fetch
+          Thread.new(Thread.current) do |parent|
+            begin
+              loop do
+                fetched_messages = partition_consumer.fetch
 
-              fetched_messages.each do |fetched_message|
-                @queue << fetched_message
+                fetched_messages.each do |fetched_message|
+                  @queue << fetched_message
+                end
               end
+            rescue => e
+              parent.raise e
             end
           end
         end

--- a/lib/poseidon/partition_consumer.rb
+++ b/lib/poseidon/partition_consumer.rb
@@ -38,10 +38,10 @@ module Poseidon
     #
     # @param [String] client_id  Used to identify this client should be unique.
     # @param [String] host
-    # @param [Integer] port 
+    # @param [Integer] port
     # @param [String] topic Topic to read from
     # @param [Integer] partition Partitions are zero indexed.
-    # @param [Integer,Symbol] offset 
+    # @param [Integer,Symbol] offset
     #   Offset to start reading from. A negative offset can also be passed.
     #   There are a couple special offsets which can be passed as symbols:
     #     :earliest_offset       Start reading from the first offset the server has.
@@ -53,7 +53,7 @@ module Poseidon
     # @option options [:max_bytes] Maximum number of bytes to fetch
     #   Default: 1048576 (1MB)
     #
-    # @option options [:max_wait_ms] 
+    # @option options [:max_wait_ms]
     #   How long to block until the server sends us data.
     #   NOTE: This is only enforced if min_bytes is > 0.
     #   Default: 100 (100ms)
@@ -70,7 +70,7 @@ module Poseidon
       @host = host
       @port = port
 
-      handle_options(options)
+      handle_options(options.dup)
 
       @connection = Connection.new(host, port, client_id, @socket_timeout_ms)
       @topic = topic
@@ -91,7 +91,7 @@ module Poseidon
     # @option options [:max_wait_ms]
     #   How long to block until the server sends us data.
     #
-    # @option options [:min_bytes] 
+    # @option options [:min_bytes]
     #   Smallest amount of data the server should send us.
     #
     # @api public
@@ -106,7 +106,7 @@ module Poseidon
 
       topic_fetches = build_topic_fetch_request(fetch_max_bytes)
       fetch_response = @connection.fetch(fetch_max_wait, fetch_min_bytes, topic_fetches)
-      topic_response = fetch_response.topic_fetch_responses.first 
+      topic_response = fetch_response.topic_fetch_responses.first
       partition_response = topic_response.partition_fetch_responses.first
 
       unless partition_response.error == Errors::NO_ERROR_CODE
@@ -209,7 +209,7 @@ module Poseidon
         @partition,
         protocol_offset,
         max_number_of_offsets = 1)
-        
+
       [Protocol::TopicOffsetRequest.new(topic, [partition_offset_request])]
     end
 

--- a/spec/integration/multiple_brokers/consumer_spec.rb
+++ b/spec/integration/multiple_brokers/consumer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "consuming with multiple brokers", :type => :request do
       msgs = fill_with_test_messages
 
       consumer = Consumer.new("test_client", %w(localhost:9092 localhost:9093 localhost:9094), "test", :earliest_offset)
-      expects(consumer.take(24).map(&:value).sort).to eq(msgs.sort)
+      expect(consumer.take(24).map(&:value).sort).to eq(msgs.sort)
     end
   end
 end

--- a/spec/unit/consumer_spec.rb
+++ b/spec/unit/consumer_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Consumer do
+  describe "creation" do
+    it "creates a consumer" do
+      consumer = Poseidon::Consumer.new("test_client", %w(localhost:9092), "test_topic", :earliest_offset)
+    end
+  end
+
+  describe "#create_partition_consumers" do
+    it "fetches metadata for the topic to create the consumers" do
+      topic = "test_topic"
+      offset = :earliest_offset
+      min_bytes = 20
+
+      partitions = [
+        PartitionMetadata.new(nil, 0, 1, [0, 1], [0, 1]),
+        PartitionMetadata.new(nil, 1, 2, [1, 0], [1, 0])
+      ]
+      topics = [TopicMetadata.new(TopicMetadataStruct.new(nil, topic, partitions))]
+      brokers = [Broker.new(1, "localhost", 9092), Broker.new(2, "localhost", 9094)]
+      metadata_response = MetadataResponse.new(nil, brokers, topics)
+
+      cluster_metadata = ClusterMetadata.new
+      cluster_metadata.update(metadata_response)
+
+
+      consumer = Poseidon::Consumer.new("test_client", %w(localhost:9092), topic, offset, :min_bytes => min_bytes)
+      consumer.stub(:fetch_cluster_metadata).and_return(cluster_metadata)
+
+      partition_consumers = consumer.send(:create_partition_consumers)
+
+      partition_consumers.each_with_index do |partition_consumer, index|
+        expect(partition_consumer.instance_variable_get(:@partition)).to eq(index)
+        expect(partition_consumer.instance_variable_get(:@topic)).to eq(topic)
+        expect(partition_consumer.instance_variable_get(:@offset)).to eq(offset)
+        expect(partition_consumer.instance_variable_get(:@host)).to eq("localhost")
+        expect(partition_consumer.instance_variable_get(:@min_bytes)).to eq(min_bytes)
+      end
+      expect(partition_consumers[0].instance_variable_get(:@port)).to eq(9092)
+      expect(partition_consumers[1].instance_variable_get(:@port)).to eq(9094)
+    end
+  end
+end

--- a/spec/unit/consumer_spec.rb
+++ b/spec/unit/consumer_spec.rb
@@ -41,4 +41,17 @@ describe Consumer do
       expect(partition_consumers[1].instance_variable_get(:@port)).to eq(9094)
     end
   end
+
+  it "bubbles up Exceptions that happen in the PartitionConsumers" do
+    fake_partition_consumer = mock()
+    fake_partition_consumer.stub(:fetch).and_raise(Poseidon::Errors::ProtocolError.new)
+
+    expect do
+      consumer = Poseidon::Consumer.new(nil, nil, nil, nil)
+      consumer.instance_variable_set(:@partition_consumers, [fake_partition_consumer])
+      consumer.each do |message|
+
+      end
+    end.to raise_error Poseidon::Errors::ProtocolError
+  end
 end


### PR DESCRIPTION
This consumer automatically consumes from all the partitions of a given topic without having to manually define how many partitions there are or having to manage the incoming messages.

I had to add a `.dup` to the options passed to PartitionConsumer because it modifies the passed options

I tried to add an integration test but I couldn't get the integration tests working locally

@hornairs
