### PR TITLE
Improve RequestBuffer performance by only encoding when necessary.

### DIFF
--- a/lib/poseidon/protocol/request_buffer.rb
+++ b/lib/poseidon/protocol/request_buffer.rb
@@ -7,12 +7,10 @@ module Poseidon
     # (https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ProtocolPrimitiveTypes) 
     class RequestBuffer
       def initialize
-        @s = ''.encode("ASCII-8BIT")
+        @s = ''
       end
 
       def append(string)
-        string = string.dup
-        string.force_encoding("ASCII-8BIT")
         @s << string
         nil
       end
@@ -55,23 +53,33 @@ module Poseidon
       end
 
       def prepend_crc32
+        ensure_ascii
         checksum_pos = @s.bytesize
         @s += " "
         yield
+        ensure_ascii
         @s[checksum_pos] = [Zlib::crc32(@s[(checksum_pos+1)..-1])].pack("N")
         nil
       end
 
       def prepend_size
+        ensure_ascii
         size_pos = @s.bytesize
         @s += " "
         yield
+        ensure_ascii
         @s[size_pos] = [(@s.bytesize-1) - size_pos].pack("N")
         nil
       end
 
       def to_s
-        @s
+        ensure_ascii
+      end
+
+      private
+
+      def ensure_ascii
+        @s.force_encoding("ASCII-8BIT")
       end
     end
   end


### PR DESCRIPTION
While doing some internal benchmarks I noticed that append was taking a fair amount of time. The string duplication can be avoided if we only ensure the encoding is "ASCII-8BIT" when we care about it.

The benchmark was a while loop sending 10,000 messages one at a time. The output is a flat print from ruby-prof.

Master:

``` bash
Benchmark: 0.9070836999999999 ms/message

Thread ID: 70308971538160
Fiber ID: 70308972131200
Total: 9.064002
Sort by: self_time

 %self      total      self      wait     child     calls  name
  7.04      1.346     0.639     0.000     0.707   180008   Poseidon::Protocol::RequestBuffer#append
  4.28      0.689     0.388     0.000     0.301   190021   Poseidon::Protocol::ProtocolStruct#type_map
  2.62      0.560     0.238     0.000     0.322   180008   Kernel#dup
  2.58      0.234     0.234     0.000     0.000   380042   Module#===
  2.58      0.234     0.234     0.000     0.000   190007   Array#pack
  2.21      0.322     0.201     0.000     0.121   180008   Kernel#initialize_dup
  2.19      0.198     0.198     0.000     0.000   360036   Kernel#class
  2.18      0.197     0.197     0.000     0.000   190021   <Class::Poseidon::Protocol::ProtocolStruct>#type_map
```

Patch:

``` bash
Benchmark: 0.8167268 ms/message

Thread ID: 70131191768800
Fiber ID: 70131192928200
Total: 8.161264
Sort by: self_time

 %self      total      self      wait     child     calls  name
  4.75      0.688     0.388     0.000     0.301   190021   Poseidon::Protocol::ProtocolStruct#type_map
  3.17      0.259     0.259     0.000     0.000   180008   Poseidon::Protocol::RequestBuffer#append
  2.99      0.244     0.244     0.000     0.000   190007   Array#pack
  2.84      0.232     0.232     0.000     0.000   380042   Module#===
  2.42      0.197     0.197     0.000     0.000   360036   Kernel#class
  2.41      0.196     0.196     0.000     0.000   190021   <Class::Poseidon::Protocol::ProtocolStruct>#type_map
```

IMO, the code is less clean than the original but it's contained within `RequestBuffer` and shows a performance gain.
