### PR TITLE
Handle broker rebalances

### DIFF
--- a/lib/poseidon.rb
+++ b/lib/poseidon.rb
@@ -4,30 +4,6 @@ require 'zlib'
 require 'thread'
 require 'set'
 
-# Public API
-require "poseidon/message_to_send"
-require "poseidon/producer"
-require "poseidon/fetched_message"
-require "poseidon/partition_consumer"
-
-# Poseidon!
-require "poseidon/message"
-require "poseidon/message_set"
-require "poseidon/topic_metadata"
-require "poseidon/protocol"
-
-require "poseidon/broker_pool"
-require "poseidon/cluster_metadata"
-require "poseidon/compression"
-require "poseidon/connection"
-require "poseidon/message_conductor"
-require "poseidon/messages_for_broker"
-require "poseidon/messages_to_send"
-require "poseidon/messages_to_send_batch"
-require "poseidon/producer_compression_config"
-require "poseidon/sync_producer"
-require "poseidon/version"
-
 # Top level Poseidon namespace
 #
 # @api public
@@ -100,3 +76,27 @@ module Poseidon
     class ProducerShutdownError < StandardError; end
   end
 end
+
+# Public API
+require "poseidon/message_to_send"
+require "poseidon/producer"
+require "poseidon/fetched_message"
+require "poseidon/partition_consumer"
+
+# Poseidon!
+require "poseidon/message"
+require "poseidon/message_set"
+require "poseidon/topic_metadata"
+require "poseidon/protocol"
+
+require "poseidon/broker_pool"
+require "poseidon/cluster_metadata"
+require "poseidon/compression"
+require "poseidon/connection"
+require "poseidon/message_conductor"
+require "poseidon/messages_for_broker"
+require "poseidon/messages_to_send"
+require "poseidon/messages_to_send_batch"
+require "poseidon/producer_compression_config"
+require "poseidon/sync_producer"
+require "poseidon/version"

--- a/lib/poseidon/messages_to_send.rb
+++ b/lib/poseidon/messages_to_send.rb
@@ -30,8 +30,8 @@ module Poseidon
       MessagesToSendBatch.new(@messages, message_conductor).messages_for_brokers
     end
 
-    def successfully_sent(messages_for_broker)
-      @messages -= messages_for_broker.messages
+    def successfully_sent(messages_sent)
+      @messages -= messages_sent
     end
 
     def all_sent?

--- a/spec/integration/multiple_brokers/rebalance_spec.rb
+++ b/spec/integration/multiple_brokers/rebalance_spec.rb
@@ -1,0 +1,64 @@
+require 'integration/multiple_brokers/spec_helper'
+
+describe "handles rebalancing" do
+  before(:each) do
+    # autocreate the topic by asking for information about it
+    @c = Connection.new("localhost", 9093, "metadata_fetcher")
+    md = @c.topic_metadata(["failure_spec"])
+    sleep 1
+  end
+
+  def current_leadership_mapping(c)
+    metadata = c.topic_metadata(["failure_spec"])
+    topic_metadata = metadata.topics.find { |t| t.name == "failure_spec" }
+    (0..2).map { |p| topic_metadata.partition_leader(p) }
+  end
+
+  it "produces a bunch of messages and consumes all without error" do
+    @p = Producer.new(["localhost:9092","localhost:9093","localhost:9094"], "test",
+                     :required_acks => -1)
+
+    1.upto(25) do |n|
+      @p.send_messages([MessageToSend.new("failure_spec", n.to_s)])
+    end
+
+    # The goal here is to have the producer attempt to send messages
+    # to a broker which is no longer the leader for the partition.
+    #
+    # We accomplish this by turning off a broker which causes leadership
+    # to failover. Then we turn that broker back on and begin sending
+    # messages. While sending messages, the kafka cluster should rebalance
+    # the partitions causing leadership to switch back to the original
+    # broker in the midst of messages being sent.
+    #
+    # We compare leadership before and after the message sending period
+    # to make sure we were successful.
+    $tc.stop_first_broker
+    sleep 30
+    $tc.start_first_broker
+
+    pre_send_leadership = current_leadership_mapping(@c)
+    26.upto(50) do |n|
+      sleep 0.5
+      @p.send_messages([MessageToSend.new("failure_spec", n.to_s)])
+    end
+    post_send_leadership = current_leadership_mapping(@c)
+
+    expect(pre_send_leadership).to_not eq(post_send_leadership)
+
+    messages = []
+    0.upto(2) do |partition|
+      consumer = PartitionConsumer.consumer_for_partition("consumer_failure_spect",
+                                                          ["localhost:9092","localhost:9093","localhost:9094"],
+                                                          "failure_spec",
+                                                          partition,
+                                                          :earliest_offset)
+      while (fetched = consumer.fetch).any?
+        messages.push(*fetched)
+      end
+    end
+
+    expect(messages.size).to eq(50)
+    expect(messages.map { |m| m.value.to_i }.sort).to eq((1..50).to_a)
+  end
+end

--- a/spec/integration/multiple_brokers/spec_helper.rb
+++ b/spec/integration/multiple_brokers/spec_helper.rb
@@ -5,7 +5,7 @@ require 'test_cluster'
 class ThreeBrokerCluster
   def initialize
     @zookeeper = ZookeeperRunner.new
-    @brokers = (9092..9094).map { |port| BrokerRunner.new(port - 9092, port, 3) }
+    @brokers = (9092..9094).map { |port| BrokerRunner.new(port - 9092, port, 3, 2) }
   end
 
   def start
@@ -16,6 +16,15 @@ class ThreeBrokerCluster
   def stop
     @zookeeper.stop
     @brokers.each(&:stop)
+  end
+
+  def stop_first_broker
+    @brokers.first.stop
+    sleep 5
+  end
+
+  def start_first_broker
+    @brokers.first.start
   end
 end
 

--- a/spec/unit/messages_to_send_spec.rb
+++ b/spec/unit/messages_to_send_spec.rb
@@ -38,7 +38,7 @@ describe MessagesToSend do
     context "is successful" do
       before(:each) do
         @mts.messages_for_brokers(nil).each do |mfb|
-          @mts.successfully_sent(mfb)
+          @mts.successfully_sent(mfb.messages)
         end
       end
 


### PR DESCRIPTION
Previously we were ignoring error values in the producer reponse.
We now leadership related errors and retry those messages.

Includes an integration test.
