### PR TITLE
Producer: timeout option is :ack_timeout_ms not :request_timeout_ms

### DIFF
--- a/lib/poseidon/producer.rb
+++ b/lib/poseidon/producer.rb
@@ -125,7 +125,7 @@ module Poseidon
     # @option options [Integer] :required_acks (0)
     #   The number of acks required per request.
     #
-    # @option options [Integer] :request_timeout_ms (1500)
+    # @option options [Integer] :ack_timeout_ms (1500)
     #   How long the producer waits for acks.
     #
     # @api public


### PR DESCRIPTION
AFAICT we are correctly setting timeouts the docs just had the name wrong.

Fix for #31 
