### PR TITLE
Consumer: block for messages by default

### DIFF
--- a/spec/integration/simple/simple_producer_and_consumer_spec.rb
+++ b/spec/integration/simple/simple_producer_and_consumer_spec.rb
@@ -54,6 +54,23 @@ describe "simple producer and consumer" do
       expect(messages.empty?).to eq(true)
     end
 
+    it "waits for messages" do
+      # Create topic
+      @c = Connection.new("localhost", 9092, "metadata_fetcher")
+      @c.topic_metadata(["simple_wait_test"])
+
+      sleep 5
+      @consumer = PartitionConsumer.new("test_consumer", "localhost", 9092,
+                                        "simple_wait_test", 0, :earliest_offset,
+                                        :max_wait_ms => 2500)
+
+      require 'benchmark'
+      n = Benchmark.realtime do
+        @consumer.fetch
+      end
+      expect(n).to be_within(0.25).of(2.5)
+    end
+
     # Not sure what's going on here, will revisit.
 =begin
     it "fetches larger messages with a larger max bytes size" do

--- a/spec/unit/partition_consumer_spec.rb
+++ b/spec/unit/partition_consumer_spec.rb
@@ -14,13 +14,13 @@ describe PartitionConsumer do
   describe "creation" do
     context "when passed unknown options" do
       it "raises an ArgumentError" do
-        expect { PartitionConsumer.new("test_client", "localhost", 9092, "test_topic", 0,:earliest_offset, :unknown => true) }.to raise_error(ArgumentError)
+        expect { PartitionConsumer.new("test_client", "localhost", 9092, "test_topic", 0, :earliest_offset, :unknown => true) }.to raise_error(ArgumentError)
       end
     end
 
     context "when passed an unknown offset" do
       it "raises an ArgumentError" do
-        expect { PartitionConsumer.new("test_client", "localhost", 9092, "test_topic", 0,:coolest_offset) }.to raise_error(ArgumentError)
+        expect { PartitionConsumer.new("test_client", "localhost", 9092, "test_topic", 0, :coolest_offset) }.to raise_error(ArgumentError)
       end
     end
   end
@@ -97,13 +97,13 @@ describe PartitionConsumer do
     end
 
     it "uses object defaults" do
-      @connection.should_receive(:fetch).with(10_000, 0, anything)
+      @connection.should_receive(:fetch).with(10_000, 1, anything)
       @pc.fetch
     end
 
     context "when options are passed" do
       it "overrides object defaults" do
-        @connection.should_receive(:fetch).with(20_000, 0, anything)
+        @connection.should_receive(:fetch).with(20_000, 1, anything)
         @pc = PartitionConsumer.new("test_client", "localhost", 9092, "test_topic", 0, :earliest_offset, :max_wait_ms => 20_000)
 
         @pc.fetch


### PR DESCRIPTION
Prior to this change min_bytes was 0 by default which causes the fetch
command to unexpectedly return regardless of the max_wait_ms setting.

Also, fixed options for PartitionConsumer#fetch to expect max_wait_ms
and not max_wait.

Resolves the issue in #27 
