### PR TITLE
socket_timeout_ms option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/version_tmp
 tmp
 *.log
 *.log.*
+tags
+.rvmrc

--- a/lib/poseidon/broker_pool.rb
+++ b/lib/poseidon/broker_pool.rb
@@ -6,11 +6,12 @@ module Poseidon
     class UnknownBroker < StandardError; end
 
     # @param [String] client_id
-    def initialize(client_id, seed_brokers)
+    def initialize(client_id, seed_brokers, socket_timeout_ms)
       @connections = {}
       @brokers = {}
       @client_id = client_id
       @seed_brokers = seed_brokers
+      @socket_timeout_ms = socket_timeout_ms
     end
 
     def fetch_metadata(topics)
@@ -52,7 +53,7 @@ module Poseidon
     private
     def fetch_metadata_from_broker(broker, topics)
       host, port = broker.split(":")
-      c = Connection.new(host, port, @client_id)
+      c = Connection.new(host, port, @client_id, @socket_timeout_ms)
       c.topic_metadata(topics)
     rescue Connection::ConnectionFailedError
       return nil
@@ -69,7 +70,7 @@ module Poseidon
       if info.nil?
         raise UnknownBroker
       end
-      Connection.new(info[:host], info[:port], @client_id)
+      Connection.new(info[:host], info[:port], @client_id, @socket_timeout_ms)
     end
   end
 end

--- a/lib/poseidon/producer.rb
+++ b/lib/poseidon/producer.rb
@@ -128,6 +128,9 @@ module Poseidon
     # @option options [Integer] :ack_timeout_ms (1500)
     #   How long the producer waits for acks.
     #
+    # @option options [Integer] :socket_timeout_ms] (10000)
+    #   How long the producer socket waits for any reply from server.
+    #
     # @api public
     def initialize(brokers, client_id, options = {})
       options = options.dup

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -21,10 +21,11 @@ module Poseidon
       :retry_backoff_ms => 100,
       :required_acks => 0,
       :ack_timeout_ms => 1500,
+      :socket_timeout_ms => 10_000
     }
 
     attr_reader :client_id, :retry_backoff_ms, :max_send_retries,
-      :metadata_refresh_interval_ms, :required_acks, :ack_timeout_ms
+      :metadata_refresh_interval_ms, :required_acks, :ack_timeout_ms, :socket_timeout_ms
     def initialize(client_id, seed_brokers, options = {})
       @client_id = client_id
 
@@ -32,7 +33,7 @@ module Poseidon
 
       @cluster_metadata   = ClusterMetadata.new
       @message_conductor  = MessageConductor.new(@cluster_metadata, @partitioner)
-      @broker_pool        = BrokerPool.new(client_id, seed_brokers)
+      @broker_pool        = BrokerPool.new(client_id, seed_brokers, socket_timeout_ms)
     end
 
     def send_messages(messages)
@@ -93,6 +94,7 @@ module Poseidon
 
     def handle_options(options)
       @ack_timeout_ms    = handle_option(options, :ack_timeout_ms)
+      @socket_timeout_ms = handle_option(options, :socket_timeout_ms)
       @retry_backoff_ms  = handle_option(options, :retry_backoff_ms)
 
       @metadata_refresh_interval_ms = 

--- a/spec/integration/multiple_brokers/consumer_spec.rb
+++ b/spec/integration/multiple_brokers/consumer_spec.rb
@@ -3,7 +3,7 @@ require 'integration/multiple_brokers/spec_helper'
 describe "consuming with multiple brokers" do
   before(:each) do
     # autocreate the topic by asking for information about it
-    c = Connection.new("localhost", 9092, "metadata_fetcher")
+    c = Connection.new("localhost", 9092, "metadata_fetcher", 10_000)
     md = c.topic_metadata(["test"])
     sleep 1
   end

--- a/spec/integration/multiple_brokers/rebalance_spec.rb
+++ b/spec/integration/multiple_brokers/rebalance_spec.rb
@@ -3,8 +3,8 @@ require 'integration/multiple_brokers/spec_helper'
 describe "producer handles rebalancing" do
   before(:each) do
     # autocreate the topic by asking for information about it
-    @c = Connection.new("localhost", 9093, "metadata_fetcher")
-    md = @c.topic_metadata(["failure_spec"])
+    @c = Connection.new("localhost", 9093, "metadata_fetcher", 10_000)
+    @c.topic_metadata(["failure_spec"])
     sleep 1
   end
 

--- a/spec/integration/multiple_brokers/round_robin_spec.rb
+++ b/spec/integration/multiple_brokers/round_robin_spec.rb
@@ -3,7 +3,7 @@ require 'integration/multiple_brokers/spec_helper'
 describe "round robin sending" do
   describe "with small message batches" do
     it "evenly distributes messages across brokers" do
-      c = Connection.new("localhost", 9092, "metadata_fetcher")
+      c = Connection.new("localhost", 9092, "metadata_fetcher", 10_000)
       md = c.topic_metadata(["test"])
       sleep 1
       md = c.topic_metadata(["test"])

--- a/spec/integration/simple/connection_spec.rb
+++ b/spec/integration/simple/connection_spec.rb
@@ -3,7 +3,7 @@ require 'integration/simple/spec_helper'
 include Protocol
 describe Connection do
   before(:each) do
-    @connection = Connection.new("localhost", 9092, "test")
+    @connection = Connection.new("localhost", 9092, "test", 10_000)
   end
 
   it 'sends and parses topic metadata requests' do

--- a/spec/integration/simple/simple_producer_and_consumer_spec.rb
+++ b/spec/integration/simple/simple_producer_and_consumer_spec.rb
@@ -56,7 +56,7 @@ describe "simple producer and consumer" do
 
     it "waits for messages" do
       # Create topic
-      @c = Connection.new("localhost", 9092, "metadata_fetcher")
+      @c = Connection.new("localhost", 9092, "metadata_fetcher", 10_000)
       @c.topic_metadata(["simple_wait_test"])
 
       sleep 5

--- a/spec/unit/sync_producer_spec.rb
+++ b/spec/unit/sync_producer_spec.rb
@@ -10,6 +10,7 @@ describe SyncProducer do
       expect(sp.metadata_refresh_interval_ms).to eq(600_000)
       expect(sp.required_acks).to eq(0)
       expect(sp.max_send_retries).to eq(3)
+      expect(sp.socket_timeout_ms).to eq(10_000)
     end
 
     it "raises ArgumentError on unknown options" do


### PR DESCRIPTION
This PR fixes the problem of hanging producer when connection between client and Kafka cluster is broken.
## How to reproduce the problem
1. Start client on client machine and Kafka on server machine connected to each other over network.
2. Run Poseidon on client machine and connect to the Kafka
3. Disconnect server machine from network
4. Produce the message
## What happens?

Poseidon waits in Socket#read. The problem is that Socket never realizes that connection is actually broken.
## What I expect

I would like Poseidon to raise an exception so I am notified about connectivity problem.

This problem has been fixed by @purbon at @Sponsorpay - I just refactored and prepared PR
