### PR TITLE
added a set_offset() method to partition_consumer.rb

### DIFF
--- a/lib/poseidon/partition_consumer.rb
+++ b/lib/poseidon/partition_consumer.rb
@@ -137,6 +137,13 @@ module Poseidon
       @offset
     end
 
+    # Set the offset (useful for seeking after initializion).
+    #
+    # @api public
+    def set_offset(offset)
+      @offset = offset
+    end
+
     # Close the connection to the kafka broker
     #
     # @return [Nil]


### PR DESCRIPTION
When Kafka has a corrupt message poseidon gets stuck attempting to read the same offset ad infinitum.  We needed to be able to skip ahead (presumably past a corrupt message or disk corruption) so we could implement logic like this:

```
docs = @kafka.fetch

# We can get stuck due to a corrupt message in Kafka.  Kafka's              
# response (possibly poseidon) doesn't distinguish between no data          
# and bad data.  Either way we simply get back an empty fetch.  To          
# get around this, we attempt to advance the offset and re-fetch.           
# If offset is past the latest offset, Kafka will throw an error            
# and we'll revert the offset.                                              

if docs.empty?
  curr_offset = @kafka.next_offset
  begin
    @kafka.set_offset(curr_offset + 1)
    docs = @kafka.fetch
  rescue Poseidon::Errors::OffsetOutOfRange => e
    @kafka.set_offset(curr_offset)
    sleep 5
  end
end
```
