### PR TITLE
Add :none option to :compression_codec

### DIFF
--- a/lib/poseidon/producer_compression_config.rb
+++ b/lib/poseidon/producer_compression_config.rb
@@ -3,15 +3,16 @@ module Poseidon
   class ProducerCompressionConfig
     COMPRESSION_CODEC_MAP = {
       :gzip   => Compression::GzipCodec,
-      :snappy => Compression::SnappyCodec
+      :snappy => Compression::SnappyCodec,
+      :none   => nil
     }
 
     def initialize(compression_codec, compressed_topics)
       if compression_codec
-        @compression_codec = COMPRESSION_CODEC_MAP[compression_codec]
-        if @compression_codec.nil?
+        unless COMPRESSION_CODEC_MAP.has_key?(compression_codec)
           raise ArgumentError, "Unknown compression codec: '#{compression_codec}' (accepted: #{COMPRESSION_CODEC_MAP.keys.inspect})"
         end
+        @compression_codec = COMPRESSION_CODEC_MAP[compression_codec]
       else
         @compression_codec = nil
       end

--- a/spec/unit/producer_compression_config_spec.rb
+++ b/spec/unit/producer_compression_config_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe ProducerCompressionConfig do
     end
   end
 
+  describe "none compression codec" do
+    it "compresses no topics" do
+      pcc = ProducerCompressionConfig.new(:none,nil)
+      expect(pcc.compression_codec_for_topic("test")).to eq(false)
+    end
+  end
+
   describe "compression codec no topics specified" do
     it "compresses any topic" do
       pcc = ProducerCompressionConfig.new(:gzip,nil)


### PR DESCRIPTION
The comment in lib/poseidon/producer.rb says users can set the option `:compression_codec` to `:none`.

``` ruby
# @option options [:gzip / :snappy / :none] :compression_codec (:none)
# Type of compression to use.
```

but I got the following error message when I set the option to `:none`.

> Unknown compression codec: 'none' (accepted: [:gzip, :snappy])

This patch enables users to set the option to `:none`.
