### PR TITLE
Allow request buffer to accept mixed encodings

### DIFF
--- a/lib/poseidon/protocol/request_buffer.rb
+++ b/lib/poseidon/protocol/request_buffer.rb
@@ -7,10 +7,11 @@ module Poseidon
     # (https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ProtocolPrimitiveTypes)
     class RequestBuffer
       def initialize
-        @s = ''
+        @s = ''.encode(Encoding::BINARY)
       end
 
       def append(string)
+        string = string.dup.force_encoding(Encoding::BINARY)
         @s << string
         nil
       end
@@ -53,33 +54,23 @@ module Poseidon
       end
 
       def prepend_crc32
-        ensure_ascii
         checksum_pos = @s.bytesize
         @s += " "
         yield
-        ensure_ascii
         @s[checksum_pos] = [Zlib::crc32(@s[(checksum_pos+1)..-1])].pack("N")
         nil
       end
 
       def prepend_size
-        ensure_ascii
         size_pos = @s.bytesize
         @s += " "
         yield
-        ensure_ascii
         @s[size_pos] = [(@s.bytesize-1) - size_pos].pack("N")
         nil
       end
 
       def to_s
-        ensure_ascii
-      end
-
-      private
-
-      def ensure_ascii
-        @s.force_encoding(Encoding::BINARY)
+        @s
       end
     end
   end

--- a/spec/unit/protocol/request_buffer_spec.rb
+++ b/spec/unit/protocol/request_buffer_spec.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+require 'spec_helper'
+include Protocol
+
+RSpec.describe RequestBuffer do
+  subject(:buffer) { Poseidon::Protocol::RequestBuffer.new }
+
+  it 'appends UTF-8 strings' do
+    expect do
+      str = 'hello ümlaut'
+      buffer.append(str)
+      buffer.append(str.force_encoding(Encoding::BINARY))
+    end.to_not raise_error
+  end
+end


### PR DESCRIPTION
Fixes #59 and undoes f7c75423ab2b7f0a5ef0847debfabf933af7df04 as suggested by @AaronLasseigne. Supersedes #60. Includes a test reproducing the error.
