### PR TITLE
bugfix: convert metadata refresh timeout to milliseconds in comparison

### DIFF
--- a/lib/poseidon/producer.rb
+++ b/lib/poseidon/producer.rb
@@ -108,7 +108,7 @@ module Poseidon
     #   Topics to compress.  If this is not specified we will compress all
     #   topics provided that +:compression_codec+ is set.
     #
-    # @option options [Integer: Seconds] :metadata_refresh_interval_ms (600_000)
+    # @option options [Integer: Milliseconds] :metadata_refresh_interval_ms (600_000)
     #   How frequently we should update the topic metadata in milliseconds.
     #
     # @option options [#call, nil] :partitioner

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -120,7 +120,7 @@ module Poseidon
 
     def refresh_interval_elapsed?
       @cluster_metadata.last_refreshed_at.nil? ||
-        (Time.now - @cluster_metadata.last_refreshed_at) > metadata_refresh_interval_ms
+        (Time.now - @cluster_metadata.last_refreshed_at) * 1000 > metadata_refresh_interval_ms
     end
 
     def refresh_metadata(topics)


### PR DESCRIPTION
This is a bug which seems to cause metadata to be refreshed once every week instead of the intended 5 minutes.
