### PR TITLE
ReplicaNotAvailable can be safely ignored

### DIFF
--- a/lib/poseidon/topic_metadata.rb
+++ b/lib/poseidon/topic_metadata.rb
@@ -56,7 +56,7 @@ module Poseidon
 
     def available_partitions
       @available_partitions ||= struct.partitions.select do |partition|
-        partition.error == 0 && partition.leader != -1
+        (partition.error == Errors::NO_ERROR_CODE || Errors::ERROR_CODES[partition.error] == Errors::ReplicaNotAvailable) && partition.leader != -1
       end
     end
 


### PR DESCRIPTION
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ErrorCodes indicates that error 9 (ReplicaNotAvailable) can be safely ignored.

This fixes #86 