### PR TITLE
Add `#to_h` and `#to_hash` to `FetchedMessage`

### DIFF
--- a/lib/poseidon/fetched_message.rb
+++ b/lib/poseidon/fetched_message.rb
@@ -12,26 +12,42 @@ module Poseidon
   # end
   # ```
   #
-  # @param [String] topic
-  #   Topic this message should be sent to.
-  #
-  # @param [String] value
-  #   Value of the message we want to send. 
-  #
-  # @param [String] key
-  #   Optional. Message's key, used to route a message
-  #   to a specific broker.  Otherwise, keys will be
-  #   sent to brokers in a round-robin manner.
-  #
   # @api public
   class FetchedMessage
     attr_reader :value, :key, :topic, :offset
 
+    # Initializes the message
+    #
+    # @param [String] topic
+    #   Topic this message fetched from.
+    #
+    # @param [String] value
+    #   Value of the message.
+    #
+    # @param [String] key
+    #   Message's key.
+    #
+    # @param [Integer] offset
+    #   The offset of the message in a topic's partition.
+    #
+    # @api private
     def initialize(topic, value, key, offset)
       @topic  = topic
       @value  = value
       @key    = key
       @offset = offset
     end
+
+    # Converts the message to a hash
+    #
+    # @return [Hash]
+    #
+    # @alias :to_hash
+    #
+    # @api public
+    def to_h
+      { topic: topic, key: key, value: value, offset: offset }
+    end
+    alias_method :to_hash, :to_h
   end
 end

--- a/spec/unit/fetched_message_spec.rb
+++ b/spec/unit/fetched_message_spec.rb
@@ -1,11 +1,31 @@
 require 'spec_helper'
 
 RSpec.describe FetchedMessage do
+  let(:mts)  { FetchedMessage.new("hello_topic", "Hello World", "key", 0) }
+  let(:hash) do
+    { topic: "hello_topic", value: "Hello World", key: "key", offset: 0 }
+  end
+
   it "provides access to topic,value,key,offset" do
-    mts = FetchedMessage.new("hello_topic", "Hello World", "key", 0)
     expect(mts.topic).to eq("hello_topic")
     expect(mts.value).to eq("Hello World")
     expect(mts.key).to eq("key")
     expect(mts.offset).to eq(0)
+  end
+
+  describe "#to_h" do
+    subject { mts.to_h }
+
+    it "converts the message to hash" do
+      expect(subject).to eql(hash)
+    end
+  end
+
+  describe "#to_hash" do
+    subject { mts.to_hash }
+
+    it "converts the message to hash" do
+      expect(subject).to eql(hash)
+    end
   end
 end


### PR DESCRIPTION
Hi! Thanks for the driver!

I'm using the `poseidon` as nuts and bolts of `rom-kafka` adapter for [ROM](https://rom-rb.org) project.

There I need to convert `FetchedMessage` to hash, using either `#to_h` or `#to_hash`.

``` ruby
message = FetchedMessage.new("hello_topic", "Hello World", "key", 0)
message.to_h
# => { topic: "hello_topic", value: "Hello World", key: "key", offset: 0 }
```

Surely, I could do this inside the adapter, but I though this kind of "general" interface worth it to be implemented in `poseidon` itself.

I've also fixed inline doc for the message (seems like it were copy-pasted from the `MessageToSend` :))
