### PR TITLE
Reset offset to :earliest_offset whenever OffsetOutOfRange happens

### DIFF
--- a/lib/poseidon/partition_consumer.rb
+++ b/lib/poseidon/partition_consumer.rb
@@ -112,8 +112,7 @@ module Poseidon
       partition_response = topic_response.partition_fetch_responses.first
 
       unless partition_response.error == Errors::NO_ERROR_CODE
-        if @offset < 0 &&
-          Errors::ERROR_CODES[partition_response.error] == Errors::OffsetOutOfRange
+        if Errors::ERROR_CODES[partition_response.error] == Errors::OffsetOutOfRange
           @offset = :earliest_offset
           return fetch(options)
         end


### PR DESCRIPTION
OffsetOutOfRange error can also happen when the returned offset is
a positive number but corresponding messages started from the offset
were retentioned