### PR TITLE
ignore under-replicated errors

### DIFF
--- a/lib/poseidon/topic_metadata.rb
+++ b/lib/poseidon/topic_metadata.rb
@@ -18,7 +18,7 @@ module Poseidon
     end
 
     # Write a binary representation of the TopicMetadata to buffer
-    # 
+    #
     # @param [RequestBuffer] buffer
     # @return [nil]
     def write(buffer)
@@ -56,7 +56,7 @@ module Poseidon
 
     def available_partitions
       @available_partitions ||= struct.partitions.select do |partition|
-        partition.error == 0 && partition.leader != -1
+        (partition.error == 0 or partition.error == 9) && partition.leader != -1
       end
     end
 


### PR DESCRIPTION
Under-replicated partitions return an error code in their metadata which indicates just that.  The Kafka docs say this can be safely ignored.

The selection for partitions did not take this soft failure into account.

Protection should still be granted based on the number of acks requested, which is a message send attribute.
