### PR TITLE
Add seek_to_offset functionality to PartitionConsumer.

### DIFF
--- a/lib/poseidon/partition_consumer.rb
+++ b/lib/poseidon/partition_consumer.rb
@@ -139,6 +139,20 @@ module Poseidon
       @offset
     end
 
+    # Causes the next fetch to proceed from this offset, rather than
+    # +next_offset+. The effect is similar to reopening a consumer, but
+    # much faster. Nonetheless, seeks shouldn't be abused because of the
+    # remoteness of Kafka.
+    #
+    # @param [Integer,Symbol] offset : the offset, similar to +initialize+.
+    #   The symbols :earliest_offset and :latest_offset are explicitly okay.
+    #
+    # @return [Nil]
+    def seek_to_offset(new_offset)
+      @offset = new_offset
+      nil
+    end
+      
     # Close the connection to the kafka broker
     #
     # @return [Nil]

--- a/spec/unit/partition_consumer_spec.rb
+++ b/spec/unit/partition_consumer_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe PartitionConsumer do
         pc = PartitionConsumer.new("test_client", "localhost", 9092, "test_topic",
                                    0, :earliest_offset)
         expect(pc.next_offset).to eq(100)
+        pc.seek_to_offset(55)
+        expect(pc.next_offset).to eq(55)
+        pc.seek_to_offset(:earliest_offset)
+        expect(pc.next_offset).to eq(100) # as before
       end
     end
 


### PR DESCRIPTION
As it turns out, it's a simple matter of changing where the next fetch
will be requested (a state variable).

The method accepts the same special offsets as the constructor.